### PR TITLE
more link text wackiness

### DIFF
--- a/src/markup/12y.js
+++ b/src/markup/12y.js
@@ -1280,7 +1280,10 @@ var toMd = node => {
 			return children();
 		case "a": {
 			const text = children();
-			return node.attr.href + (text && text !== node.attr.href ? " [" + text + "] " : "");
+			const href = node.attr.href.startsWith("sbs:") ?
+				"https://smilebasicsource.com/?p=" + node.attr.href.substr(4).replace(/\//g, "-")
+				: node.attr.href;
+			return href + (text && text !== node.attr.href ? " [" + text + "] " : "");
 		}
 		case "img":
 			return node.attr.src + (node.attr.alt ? " [" + node.attr.alt + "]" : "") + "\n";
@@ -1509,7 +1512,6 @@ Parse.options = {
 	},
 	simpleLink(args) {
 		var link = this.createLink(args[""]);
-		link.node.children = [args[""]];
 		return link;
 	},
 	customLink(args) {


### PR DESCRIPTION
issue that if the link contained characters that need to be escaped (notably underscores) link text would be added as the link but with backslashes
this fixes it

also resolve sbs: links to something clickable in discord