### PR TITLE
fix text immediately after a blockquote

### DIFF
--- a/src/markup/md-to-12y.js
+++ b/src/markup/md-to-12y.js
@@ -121,7 +121,7 @@ const to12y = tokens => {
 				break;
 			}
 			case "blockQuote":
-				out += ">{" + to12y(token.content) + "}";
+				out += ">{" + to12y(token.content) + "}\n";
 				break;
 		}
 	}


### PR DESCRIPTION
it turns out 12y doesn't consider `>{text}text` to be a blockquoted environment followed by plaintext, but a blockquote of "{text}text", so newlines need to be added after blockquote environments.